### PR TITLE
Extend threadpool

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -7,6 +7,7 @@ const async = require('async');
 const uuidV4 = require('uuid/v4');
 const support = require('./lib/support.js')();
 global.config = require('./config.json');
+process.env.UV_THREADPOOL_SIZE = 128;
 
 /*
  General file design/where to find things.


### PR DESCRIPTION
Avoid read ETIMEDOUT errors on high traffic servers with extending threadpool