### PR TITLE
Update install.sh to latest NodeJS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ cd ~
 git clone https://github.com/Snipa22/xmr-node-proxy
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
 source ~/.nvm/nvm.sh
-nvm install v6.9.2
+nvm install v8.4.0
 cd ~/xmr-node-proxy
 npm install
 npm install -g pm2
@@ -22,7 +22,7 @@ cp config_example.json config.json
 openssl req -subj "/C=IT/ST=Pool/L=Daemon/O=Mining Pool/CN=mining.proxy" -newkey rsa:2048 -nodes -keyout cert.key -x509 -out cert.pem -days 36500
 cd ~
 pm2 status
-sudo env PATH=$PATH:`pwd`/.nvm/versions/node/v6.9.2/bin `pwd`/.nvm/versions/node/v6.9.2/lib/node_modules/pm2/bin/pm2 startup systemd -u $CURUSER --hp `pwd`
+sudo env PATH=$PATH:`pwd`/.nvm/versions/node/v8.4.0/bin `pwd`/.nvm/versions/node/v8.4.0/lib/node_modules/pm2/bin/pm2 startup systemd -u $CURUSER --hp `pwd`
 sudo chown -R $CURUSER. ~/.pm2
 echo "Installing pm2-logrotate in the background!"
 pm2 install pm2-logrotate &


### PR DESCRIPTION
The install now fails on Ubuntu 16.04 with v6.9.2. Upgrading to v8.4.0 solves all install errors and provides a successful installation