### PR TITLE
Update the last contact time when we receive a keepalive message.

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -945,6 +945,7 @@ function handleMinerData(method, params, ip, portData, sendReply, pushMessage, m
                 sendReply('Unauthenticated');
                 return;
             }
+            miner.heartbeat();
             sendReply(null, {
                 status: 'KEEPALIVED'
             });


### PR DESCRIPTION
Keepalive messages from miners were not previously updating the lastContact time on the miner object. This leads to slower miners being pruned after the two minute timeout while they were still working. When a slow miner finished and submitted their job, the proxy would no longer have information regarding it and would return an "Invalid job id" error.