### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,92 @@
-FROM ubuntu:16.04
+# FROM buster AS builder for GCC 7+
+FROM buildpack-deps:buster AS builder
 
-RUN apt-get update \
-    && apt-get -y upgrade \
-    && apt-get install -y git python-virtualenv python3-virtualenv curl ntp build-essential screen cmake pkg-config libboost-all-dev libevent-dev libunbound-dev libminiupnpc-dev libunwind8-dev liblzma-dev libldns-dev libexpat1-dev libgtest-dev libzmq3-dev
+### Verbatim from nodejs 6 Dockerfile
+ENV NODE_VERSION 6.9.2
 
-RUN curl -fsSL https://deb.nodesource.com/setup_6.x -o /tmp/node_setup.sh \
-    && bash /tmp/node_setup.sh \
-    && rm /tmp/node_setup.sh \
-    && apt-get install -y nodejs
+# gpg keys listed at https://github.com/nodejs/node#release-team
+RUN set -ex \
+  && for key in \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done
 
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.5.1
+
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+
+### End verbatim from nodejs 6 Dockerfile
+
+# xmr-node-proxy build dependencies
+RUN apt-get update && apt-get -y install build-essential libboost-all-dev libevent-dev libunbound-dev libminiupnpc-dev libunwind8-dev liblzma-dev libldns-dev libexpat1-dev libgtest-dev libzmq3-dev cmake pkg-config
+
+# Copy in source for npm install
 COPY . /app/
 
-RUN cd /app/ \
-    && npm install \
-    && cp -n config_example.json config.json \
-    && openssl req -subj "/C=IT/ST=Pool/L=Daemon/O=Mining Pool/CN=mining.proxy" -newkey rsa:2048 -nodes -keyout cert.key -x509 -out cert.pem -days 36500
+# Install/build/compile dependencies
+WORKDIR /app
+RUN npm install
 
-EXPOSE 8080 8443 3333
+# Runtime container setup
+FROM debian:buster-slim
 
+# Install runtime dependencies only
+RUN apt-get update && apt-get -y install openssl libboost-system1.62.0 libboost-date-time1.62.0 libevent-2.1-6 libunbound2 libminiupnpc16 libunwind8 liblzma5 libldns2 libexpat1 libzmq5
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+# Copy from builder stage
+COPY --from=builder /opt /opt
+COPY --from=builder /usr/local /usr/local
+COPY --from=builder --chown=node:node /app /app
+
+USER node
 WORKDIR /app/
+
+RUN openssl req -subj "/C=IT/ST=Pool/L=Daemon/O=Mining Pool/CN=mining.proxy" -newkey rsa:2048 -nodes -keyout cert.key -x509 -out cert.pem -days 36500
+
 CMD ["node", "proxy.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:16.04
+
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install -y git python-virtualenv python3-virtualenv curl ntp build-essential screen cmake pkg-config libboost-all-dev libevent-dev libunbound-dev libminiupnpc-dev libunwind8-dev liblzma-dev libldns-dev libexpat1-dev libgtest-dev libzmq3-dev
+
+RUN curl -fsSL https://deb.nodesource.com/setup_6.x -o /tmp/node_setup.sh \
+    && bash /tmp/node_setup.sh \
+    && rm /tmp/node_setup.sh \
+    && apt-get install -y nodejs
+
+COPY . /app/
+
+RUN cd /app/ \
+    && npm install \
+    && cp -n config_example.json config.json \
+    && openssl req -subj "/C=IT/ST=Pool/L=Daemon/O=Mining Pool/CN=mining.proxy" -newkey rsa:2048 -nodes -keyout cert.key -x509 -out cert.pem -days 36500
+
+EXPOSE 8080 8443 3333
+
+WORKDIR /app/
+CMD ["node", "proxy.js"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ or using the pm2 monitor
 pm2 monit
 ```
 
+## Deployment via Docker
+
+1. Build the image
+
+```
+docker build . -t xmr-node-proxy
+```
+2. Run the container, add custom config, expose some ports
+
+```
+docker run -v $PWD/config.json:/app/config.json -p 3333:3333 -p 8080:8080 -p 8443:8443 xmr-node-proxy
+```
+
 ## Known Issues
 
 VMs with 512Mb or less RAM will need some swap space in order to compile the C extensions for node.  Bignum and the CN libraries can chew through some serious memory during compile.  In regards to this, one of our users has put together a guide for T2.Micro servers: https://docs.google.com/document/d/1m8E4_pDwKuFo0TnWJaO13LDHqOmbL6YrzyR6FvzqGgU (Credit goes to MayDay30 for his work with this!)


### PR DESCRIPTION
This is an update to #16 which uses a multistage docker file based on Debian Buster for gcc 7+. Total size is only 167MB.

It requires a fixed cryptonote-util so this should be merged before this builds: https://github.com/Snipa22/node-cryptonote-util/pull/2 (or a similar fix); alternatively, package.json can be update to use:

```
    "cryptonote-util": "git+https://github.com/infernix/node-cryptonote-util.git#xmr-Nan-2.0-gcc67fix",
```


